### PR TITLE
Fixing issue with pinned versions of the dependencies of the package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,10 @@ homepage = "https://bitwarden.com/products/passwordless"
 documentation = "https://docs.passwordless.dev/guide"
 
 [tool.poetry.dependencies]
-python = "3.8.18"
-requests = "2.31.0"
-marshmallow = "3.21.1"
-python-dateutil = "2.9.0.post0"
+python = ">=3.8"
+requests = ">=2.31"
+marshmallow = ">=3.21"
+python-dateutil = ">=2.9"
 
 [tool.poetry.group.dev]
 optional = true


### PR DESCRIPTION
### Description

In release [1.0.0](https://github.com/bitwarden/passwordless-python/blob/v1.0.0/pyproject.toml)
the requirements of the package have changed to pinned versions from caret (^) versions. This means
that installing passwordless version 1.0.0 requires you to have Python 3.8.18 installed otherwise
the installation will fail. In release [0.1.1](https://github.com/bitwarden/passwordless-python/blob/v0.1.1/pyproject.toml) the dependency definition was as follows:

```toml
[tool.poetry.dependencies]
python = "^3.8"
passwordless = "^0"
flask = "^2"
flasgger = "^0"
flask-marshmallow = "^0"
```

I propose a change to ">=" versions rather than caret to avoid unnecessary package lock-in
effects if there are no known breaking changes in the next major versions of the dependencies.
This also aligns with "better ask for forgiveness rather than permission". If a breaking change
is found in a next major version of a dependency, then this issue will likely be found faster
and fixed. In worst case, if no fix is available, a new version with a "<" version requirement
can be released.

You can decide if you want to also update your test requirements in the same manner.

## Proposed change

```toml
[tool.poetry.dependencies]
python = ">=3.8"
requests = ">=2.31"
marshmallow = ">=3.21"
python-dateutil = ">=2.9"
```

## Steps to reproduce

1. Install a version of Python >= 3.8.18

2. Run the command `pip install passwordless==1.0.0` or `python -m pip install passwordless==1.0.0`

### Example

```bash
(test_passwordless) $ python --version
Python 3.12.2
(test_passwordless) $ pip install passwordless==1.0.0
ERROR: Ignored the following versions that require a different python version: 1.0.0 Requires-Python ==3.8.18
ERROR: Could not find a version that satisfies the requirement passwordless==1.0.0 (from versions: 0.1.0, 0.1.1)
ERROR: No matching distribution found for passwordless==1.0.0
```