### PR TITLE
Change renovate pinning to only pin lockfile

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>bitwarden/renovate-config"]
+  "extends": ["github>bitwarden/renovate-config"],
+  "packageRules": [
+    {
+      "matchManagers": "poetry",
+      "rangeStrategy": "update-lockfile"
+    }
+  ]
 }


### PR DESCRIPTION
Fix for the https://github.com/bitwarden/passwordless-python/pull/42 problem, which ended up in revert https://github.com/bitwarden/passwordless-python/pull/43 as a temporary measure


### Description
Passwordless python sdk library is compatible with of python 3.8 or newer, but as a result of Renovate default pinning behaviour, the dependencies, including python gets pinned to newest versions, which results in the SDK only being compatible with specific python version.
To expected behaviour is that the _pyproject.toml_ file contains the ranges, while the _poetry.lock_ file get's updated on dependency update.

### Shape
This PR changes the renovate pinning behaviour for poetry libraries to only update the lock file based on acceptable poetry project ranges.

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- Unable to test until merged

I did the following to ensure that my changes do not introduce security vulnerabilities:
- N/A