### PR TITLE
[BRE-1935] Migrate workflow: cd.yml (Phase 2)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,38 +1,31 @@
+---
 name: Release
 
 on:
   release:
     types: [created]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish (e.g., v1.2.3)"
+        required: true
+        type: string
+
+permissions:
+  deployments: write
 
 jobs:
-  publish:
-    name: Publish
-    environment: PyPI
+  trigger-publish:
+    name: Trigger Publish in Deploy Repo
     runs-on: ubuntu-24.04
     permissions:
-      contents: read
-      id-token: write
+      deployments: write
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Trigger publish via bitwarden/deploy
+        uses: bitwarden/gh-actions/trigger-actions@main
         with:
-          persist-credentials: false
-
-      - name: Install poetry
-        run: pipx install poetry
-
-      - name: Set up Python
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
-        with:
-          python-version: '3.10'
-          cache: 'poetry'
-
-      - name: Setup
-        run: poetry env use 3.10
-
-      - name: Environment information
-        run: poetry env info
-      - name: Build package
-        run: poetry build
-      - name: Publish - PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+          task: publish-passwordless-python
+          data: |
+            {
+              "tag": "${{ inputs.tag || github.event.release.tag_name }}"
+            }

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,8 +11,7 @@ on:
         required: true
         type: string
 
-permissions:
-  deployments: write
+permissions: {}
 
 jobs:
   trigger-publish:
@@ -20,10 +19,14 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       deployments: write
+      id-token: write
     steps:
       - name: Trigger publish via bitwarden/deploy
         uses: bitwarden/gh-actions/trigger-actions@main
         with:
+          azure_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
+          azure_client_id: ${{ secrets.AZURE_CLIENT_ID }}
           task: publish-passwordless-python
           data: |
             {


### PR DESCRIPTION
## Summary

This is **Phase 2 (finalize-source)** of the BRE-1935 migration for the `cd.yml` workflow.

**Phase 1** (already merged in bitwarden/deploy): https://github.com/bitwarden/deploy/pull/275

## What This Does

Converts the source repo's `cd.yml` from a full PyPI publishing workflow to a lightweight trigger-actions caller that dispatches to the centralized workflow in `bitwarden/deploy`.

## Changes

### Before (47 lines)
- Full build logic (poetry, python setup, build, publish)
- Triggered only by `release: [created]`
- No manual dispatch option

### After (31 lines)  
- Lightweight trigger-actions caller
- **Preserves** `release: [created]` trigger (automatic on release)
- **Adds** `workflow_dispatch` trigger (manual dispatch option)
- Forwards release tag to bitwarden/deploy

## Developer Experience

### Automatic (unchanged)
When a release is created in this repo, the workflow automatically triggers and dispatches to bitwarden/deploy for publishing.

### Manual Dispatch (new)
Developers can now manually trigger publishing from this repo:
```bash
gh workflow run cd.yml --repo bitwarden/passwordless-python -f tag=v1.2.3
```

### Actual Publishing Logic
Now lives in: `bitwarden/deploy/.github/workflows/publish-passwordless-python.yml`

## Migration Phases

- ✅ **Phase 1**: Centralized workflow in bitwarden/deploy (PR #275 - merged)
- ⏳ **Phase 2** (this PR): Replace source workflow with trigger-actions caller  
- ⏳ **Phase 3**: Wire trigger receiver in bitwarden/deploy's trigger-actions.yml

## Testing

After merge:
- Create a test release and verify it triggers the deploy workflow
- Test manual dispatch: `gh workflow run cd.yml -f tag=<test-tag>`

## Documentation

No documentation references to `cd.yml` were found in this repo.